### PR TITLE
chore(test-utils): add exampleTwo Poi

### DIFF
--- a/core/cypress/utils/test-utils.ts
+++ b/core/cypress/utils/test-utils.ts
@@ -149,5 +149,6 @@ export const data = {
   },
   pois: {
     exampleOne: 'Poi example one',
+    exampleTwo: 'Poi example two',
   },
 };


### PR DESCRIPTION
This commit adds a new Poi called "exampleTwo" to the test-utils file in the core/cypress/utils directory.
