### PR TITLE
chore(test-utils): add exampleTwo to pois

### DIFF
--- a/core/cypress/utils/test-utils.ts
+++ b/core/cypress/utils/test-utils.ts
@@ -149,5 +149,6 @@ export const data = {
   },
   pois: {
     exampleOne: 'Poi example one',
+    exampleTwo: 'Poi example two',
   },
 };


### PR DESCRIPTION
This commit adds the 'exampleTwo' property to the 'pois' object in the test-utils file.
